### PR TITLE
Make executor::execute & executor::async_execute receive one shared para...

### DIFF
--- a/agency/cuda/block_executor.hpp
+++ b/agency/cuda/block_executor.hpp
@@ -23,11 +23,11 @@ struct block_executor_helper_functor
     f_(agency::detail::get<1>(idx));
   }
 
-  template<class Tuple>
+  template<class T>
   __device__
-  void operator()(grid_executor::index_type idx, Tuple&& shared_params)
+  void operator()(grid_executor::index_type idx, const agency::detail::ignore_t&, T& inner_shared_param)
   {
-    f_(agency::detail::get<1>(idx), agency::detail::get<1>(shared_params));
+    f_(agency::detail::get<1>(idx), inner_shared_param);
   }
 };
 
@@ -80,17 +80,17 @@ class block_executor : private grid_executor
     }
 
     template<class Function, class T>
-    future<void> async_execute(Function f, shape_type shape, T shared_arg)
+    future<void> async_execute(Function f, shape_type shape, T shared_init)
     {
       auto g = detail::block_executor_helper_functor<Function>{f};
-      return traits::async_execute(*this, g, super_t::shape_type{1,shape}, agency::detail::make_tuple(agency::detail::ignore, shared_arg));
+      return traits::async_execute(*this, g, super_t::shape_type{1,shape}, agency::detail::ignore, shared_init);
     }
 
     template<class Function, class T>
-    void execute(Function f, shape_type shape, T shared_arg)
+    void execute(Function f, shape_type shape, T shared_init)
     {
       auto g = detail::block_executor_helper_functor<Function>{f};
-      traits::execute(*this, g, super_t::shape_type{1,shape}, agency::detail::make_tuple(agency::detail::ignore, shared_arg));
+      traits::execute(*this, g, super_t::shape_type{1,shape}, agency::detail::ignore, shared_init);
     }
 };
 

--- a/agency/detail/shared_parameter.hpp
+++ b/agency/detail/shared_parameter.hpp
@@ -206,10 +206,10 @@ using unpack_shared_parameters_from_executor_t = extracted_shared_parameters_t<t
 
 template<class... Rows>
 __AGENCY_ANNOTATION
-unpack_shared_parameters_from_executor_t<tuple<Rows...>>
-  unpack_shared_parameters_from_executor(tuple<Rows...>& shared_param_matrix)
+unpack_shared_parameters_from_executor_t<tuple<Rows&...>>
+  unpack_shared_parameter_matrix_from_executor(tuple<Rows&...> shared_param_matrix)
 {
-  const size_t num_columns = tuple_matrix_shape<tuple<Rows...>>::columns;
+  const size_t num_columns = tuple_matrix_shape<tuple<Rows&...>>::columns;
 
   // to transform the shared_param_matrix into a tuple of shared parameters
   // we need to find the actual (non-null) parameter in each column of the matrix
@@ -219,6 +219,15 @@ unpack_shared_parameters_from_executor_t<tuple<Rows...>>
       shared_param_matrix
     )
   );
+}
+
+
+template<class... Types>
+__AGENCY_ANNOTATION
+unpack_shared_parameters_from_executor_t<tuple<Types&...>>
+  unpack_shared_parameters_from_executor(Types&... shared_params)
+{
+  return detail::unpack_shared_parameter_matrix_from_executor(detail::tie(shared_params...));
 }
 
 

--- a/test_grid_executor.cu
+++ b/test_grid_executor.cu
@@ -1,4 +1,6 @@
 #include <agency/cuda/grid_executor.hpp>
+#include <iostream>
+#include <cstdio>
 
 struct hello_world
 {
@@ -12,13 +14,9 @@ struct hello_world
 
 struct with_shared_arg
 {
-  // XXX figure out what to do about our use of tuple here
   __device__
-  void operator()(agency::uint2 index, agency::detail::tuple<int&,int&> shared_arg)
+  void operator()(agency::uint2 index, int& outer_shared, int& inner_shared)
   {
-    int& outer_shared = agency::detail::get<0>(shared_arg);
-    int& inner_shared = agency::detail::get<1>(shared_arg);
-
     atomicAdd(&outer_shared, 1);
     atomicAdd(&inner_shared, 1);
 
@@ -75,7 +73,7 @@ int main()
   cudaDeviceSynchronize();
 
   std::cout << "Testing bulk_invoke with shared arg on host" << std::endl;
-  ex.execute(with_shared_arg(), agency::uint2{2,2}, thrust::make_tuple(7,13));
+  ex.execute(with_shared_arg(), agency::uint2{2,2}, 7, 13);
   cudaDeviceSynchronize();
 
   std::cout << "Testing bulk_invoke() on device" << std::endl;

--- a/test_nested_executor.cpp
+++ b/test_nested_executor.cpp
@@ -21,28 +21,29 @@ int main()
   std::cout << std::endl;
 
   // test with shared variables
-  ex.async_execute([](std::tuple<size_t,size_t> idx, std::tuple<int&,int&> shared)
+  ex.async_execute([](std::tuple<size_t,size_t> idx, int& shared0, int& shared1)
   {
     mut.lock();
     if(std::get<0>(idx) == 0 && std::get<1>(idx) == 0)
     {
       // set the first shared variable to 7
-      std::get<0>(shared) = 7;
+      shared0 = 7;
     }
     mut.unlock();
 
     mut.lock();
     std::cout << "Hello world from thread " << std::this_thread::get_id() << std::endl;
     std::cout << "Hello world from index " << std::get<0>(idx) << ", " << std::get<1>(idx) << std::endl;
-    std::cout << "1st shared variable: " << std::get<0>(shared) << std::endl;
-    std::cout << "2nd shared variable: " << std::get<1>(shared) << std::endl;
+    std::cout << "1st shared variable: " << shared0 << std::endl;
+    std::cout << "2nd shared variable: " << shared1 << std::endl;
     mut.unlock();
 
     // increment 2nd shared variable
-    ++std::get<1>(shared);
+    ++shared1;
   },
   std::make_pair(2,2),
-  std::make_tuple(13,0)).wait();
+  13, 0
+  ).wait();
 
   std::cout << std::endl;
 
@@ -59,20 +60,20 @@ int main()
   std::cout << std::endl;
 
   // test with shared variables
-  ex2.async_execute([](std::tuple<size_t,size_t,size_t> idx, std::tuple<int&,int&,int&> shared)
+  ex2.async_execute([](std::tuple<size_t,size_t,size_t> idx, int& shared0, int& shared1, int& shared2)
   {
     std::cout << "(" << std::get<0>(idx) << ", " << std::get<1>(idx) << ", " << std::get<2>(idx) << ")" << std::endl;
-    std::cout << "1st shared variable: " << std::get<0>(shared) << std::endl;
-    std::cout << "2nd shared variable: " << std::get<1>(shared) << std::endl;
-    std::cout << "3rd shared variable: " << std::get<2>(shared) << std::endl;
+    std::cout << "1st shared variable: " << shared0 << std::endl;
+    std::cout << "2nd shared variable: " << shared1 << std::endl;
+    std::cout << "3rd shared variable: " << shared2 << std::endl;
 
     // increment shared variables
-    std::get<0>(shared) += 1;
-    std::get<1>(shared) += 2;
-    std::get<2>(shared) += 3;
+    shared0 += 1;
+    shared1 += 2;
+    shared2 += 3;
   },
   std::make_tuple(2,2,2),
-  std::make_tuple(13,0,7)
+  13, 0, 7
   ).wait();
 
 


### PR DESCRIPTION
...meter per level of execution rather than everything packed into a tuple

Fixes #12