### PR TITLE
Osx fix

### DIFF
--- a/agency/coordinate.hpp
+++ b/agency/coordinate.hpp
@@ -796,10 +796,6 @@ namespace std
 {
 
 
-//template<size_t I, class Tuple>
-//struct tuple_element;
-
-
 template<size_t I, class T, size_t Rank>
 struct tuple_element<I,agency::point<T,Rank>>
 {

--- a/agency/coordinate.hpp
+++ b/agency/coordinate.hpp
@@ -796,8 +796,8 @@ namespace std
 {
 
 
-template<size_t I, class Tuple>
-struct tuple_element;
+//template<size_t I, class Tuple>
+//struct tuple_element;
 
 
 template<size_t I, class T, size_t Rank>

--- a/agency/detail/tuple_impl.hpp
+++ b/agency/detail/tuple_impl.hpp
@@ -61,7 +61,7 @@ namespace std
 {
 
 
-template<size_t, class> struct tuple_element;
+//template<size_t, class> struct tuple_element;
 
 
 template<size_t i>
@@ -82,7 +82,7 @@ struct tuple_element<i, __TUPLE_NAMESPACE::tuple<Type1,Types...>>
 };
 
 
-template<class> struct tuple_size;
+//template<class> struct tuple_size;
 
 
 template<class... Types>


### PR DESCRIPTION
Build C++ examples on OSX:

    $ clang++ -std=c++11 saxpy.cpp -I./  && ./a.out       
    OK
    $ clang++ -std=c++11 sort.cpp -I./  && ./a.out     
    OK
    $ clang++ -std=c++11 test_shared.cpp  -I./  && ./a.out     
    [works with a lot of output]


But getting error form CUDA examples:

    $ nvcc -std=c++11 saxpy.cu  -I./  && ./a.out                                      
    ./agency/detail/tuple_impl.hpp(741): error: namespace "std" has no member "get"
    
    ./agency/detail/tuple_impl.hpp(747): error: namespace "std" has no member "get"
    
    ./agency/detail/tuple_impl.hpp(753): error: namespace "std" has no member "get"
    
    3 errors detected in the compilation of "/var/folders/3q/bvdwl5dj72g53sldd774gdq80000gn/T//tmpxft_00009ad0_00000000-9_saxpy.cpp1.ii".

Any idea why it is so? It appears to be of the similar nature as Intel C++ compiler produced on fixed tuple (bottom of https://github.com/jaredhoberock/tuple/issues/26)