### PR TITLE
Workaround for possible NVCC bug that prevents use of agency on OSX

### DIFF
--- a/agency/detail/tuple_impl.hpp
+++ b/agency/detail/tuple_impl.hpp
@@ -48,68 +48,20 @@
 #endif
 
 #if defined __NVCC__ && (defined __APPLE__ || defined __MACOSX)
-// Workaround for NVCC bug on OSX -- shamelessly copied from GCC <utility> header
-namespace __nvcc_osx_get_fix
+namespace std 
 {
-  template<std::size_t _Int>
-    struct __pair_get;
+  template<std::size_t _Int, class _Tuple>
+    constexpr typename std::tuple_element<_Int, _Tuple>::type&
+    get(_Tuple& __in) noexcept;
 
-  template<>
-    struct __pair_get<0>
-    {
-      template<typename _Tp1, typename _Tp2>
-        static constexpr _Tp1&
-        __get(std::pair<_Tp1, _Tp2>& __pair) noexcept
-        { return __pair.first; }
+  template<std::size_t _Int, class _Tuple>
+    constexpr typename std::tuple_element<_Int, _Tuple>::type&&
+    get(_Tuple&& __in) noexcept;
 
-      template<typename _Tp1, typename _Tp2>
-        static constexpr _Tp1&&
-        __move_get(std::pair<_Tp1, _Tp2>&& __pair) noexcept
-        { return std::forward<_Tp1>(__pair.first); }
-
-      template<typename _Tp1, typename _Tp2>
-        static constexpr const _Tp1&
-        __const_get(const std::pair<_Tp1, _Tp2>& __pair) noexcept
-        { return __pair.first; }
-    };
-
-  template<>
-    struct __pair_get<1>
-    {
-      template<typename _Tp1, typename _Tp2>
-        static constexpr _Tp2&
-        __get(std::pair<_Tp1, _Tp2>& __pair) noexcept
-        { return __pair.second; }
-
-      template<typename _Tp1, typename _Tp2>
-        static constexpr _Tp2&&
-        __move_get(std::pair<_Tp1, _Tp2>&& __pair) noexcept
-        { return std::forward<_Tp2>(__pair.second); }
-
-      template<typename _Tp1, typename _Tp2>
-        static constexpr const _Tp2&
-        __const_get(const std::pair<_Tp1, _Tp2>& __pair) noexcept
-        { return __pair.second; }
-    };
-
-  template<std::size_t _Int, class _Tp1, class _Tp2>
-    constexpr typename std::tuple_element<_Int, std::pair<_Tp1, _Tp2>>::type&
-    get(std::pair<_Tp1, _Tp2>& __in) noexcept
-    { return __pair_get<_Int>::__get(__in); }
-
-  template<std::size_t _Int, class _Tp1, class _Tp2>
-    constexpr typename std::tuple_element<_Int, std::pair<_Tp1, _Tp2>>::type&&
-    get(std::pair<_Tp1, _Tp2>&& __in) noexcept
-    { return __pair_get<_Int>::__move_get(std::move(__in)); }
-
-  template<std::size_t _Int, class _Tp1, class _Tp2>
-    constexpr const typename std::tuple_element<_Int, std::pair<_Tp1, _Tp2>>::type&
-    get(const std::pair<_Tp1, _Tp2>& __in) noexcept
-    { return __pair_get<_Int>::__const_get(__in); }
+  template<std::size_t _Int, class _Tuple>
+    constexpr typename std::tuple_element<_Int, _Tuple>::type&
+    get(const _Tuple& __in) noexcept;
 }
-#define NVCC_OSX_GET_FIX __nvcc_osx_get_fix
-#else
-#define NVCC_OSX_GET_FIX std
 #endif
 
 
@@ -803,19 +755,19 @@ class tuple
     template<size_t i, class... UTypes>
     friend __TUPLE_ANNOTATION
     typename std::tuple_element<i, __TUPLE_NAMESPACE::tuple<UTypes...>>::type &
-    NVCC_OSX_GET_FIX::get(__TUPLE_NAMESPACE::tuple<UTypes...>& t);
+    std::get(__TUPLE_NAMESPACE::tuple<UTypes...>& t);
 
 
     template<size_t i, class... UTypes>
     friend __TUPLE_ANNOTATION
     const typename std::tuple_element<i, __TUPLE_NAMESPACE::tuple<UTypes...>>::type &
-    NVCC_OSX_GET_FIX::get(const __TUPLE_NAMESPACE::tuple<UTypes...>& t);
+    std::get(const __TUPLE_NAMESPACE::tuple<UTypes...>& t);
 
 
     template<size_t i, class... UTypes>
     friend __TUPLE_ANNOTATION
     typename std::tuple_element<i, __TUPLE_NAMESPACE::tuple<UTypes...>>::type &&
-    NVCC_OSX_GET_FIX::get(__TUPLE_NAMESPACE::tuple<UTypes...>&& t);
+    std::get(__TUPLE_NAMESPACE::tuple<UTypes...>&& t);
 };
 
 
@@ -904,7 +856,7 @@ struct __find_exactly_one : __find_exactly_one_impl<0,T,Types...>
 
 
 // implement std::get()
-namespace NVCC_OSX_GET_FIX
+namespace std
 {
 
 

--- a/agency/detail/tuple_impl.hpp
+++ b/agency/detail/tuple_impl.hpp
@@ -48,7 +48,7 @@
 #endif
 
 #if defined __NVCC__ && (defined __APPLE__ || defined __MACOSX)
-// Workaround for NVCC bug on OSX
+// Workaround for NVCC bug on OSX -- shamelessly copied from GCC <utility> header
 namespace __nvcc_osx_get_fix
 {
   template<std::size_t _Int>

--- a/agency/detail/tuple_impl.hpp
+++ b/agency/detail/tuple_impl.hpp
@@ -47,24 +47,6 @@
 #define __TUPLE_NAMESPACE_NEEDS_UNDEF
 #endif
 
-#if defined __NVCC__ && (defined __APPLE__ || defined __MACOSX)
-namespace std 
-{
-  template<std::size_t _Int, class _Tuple>
-    constexpr typename std::tuple_element<_Int, _Tuple>::type&
-    get(_Tuple& __in) noexcept;
-
-  template<std::size_t _Int, class _Tuple>
-    constexpr typename std::tuple_element<_Int, _Tuple>::type&&
-    get(_Tuple&& __in) noexcept;
-
-  template<std::size_t _Int, class _Tuple>
-    constexpr typename std::tuple_element<_Int, _Tuple>::type&
-    get(const _Tuple& __in) noexcept;
-}
-#endif
-
-
 namespace __TUPLE_NAMESPACE
 {
 
@@ -538,6 +520,47 @@ class __tuple_base<__tuple_index_sequence<I...>, Types...>
     static void swallow(Args&&...) {}
 };
 
+} // end namespace
+
+// implement std::get()
+namespace std
+{
+
+
+template<size_t i, class... UTypes>
+__TUPLE_ANNOTATION
+typename std::tuple_element<i, __TUPLE_NAMESPACE::tuple<UTypes...>>::type &
+  get(__TUPLE_NAMESPACE::tuple<UTypes...>& t)
+{
+  return t.template mutable_get<i>();
+}
+
+
+template<size_t i, class... UTypes>
+__TUPLE_ANNOTATION
+const typename std::tuple_element<i, __TUPLE_NAMESPACE::tuple<UTypes...>>::type &
+  get(const __TUPLE_NAMESPACE::tuple<UTypes...>& t)
+{
+  return t.template const_get<i>();
+}
+
+
+template<size_t i, class... UTypes>
+__TUPLE_ANNOTATION
+typename std::tuple_element<i, __TUPLE_NAMESPACE::tuple<UTypes...>>::type &&
+  get(__TUPLE_NAMESPACE::tuple<UTypes...>&& t)
+{
+  using type = typename std::tuple_element<i, __TUPLE_NAMESPACE::tuple<UTypes...>>::type;
+
+  auto&& leaf = static_cast<__TUPLE_NAMESPACE::__tuple_leaf<i,type>&&>(t.base());
+
+  return static_cast<type&&>(leaf.mutable_get());
+}
+
+} // end std
+
+namespace __TUPLE_NAMESPACE
+{
 
 template<class... Types>
 class tuple
@@ -858,38 +881,6 @@ struct __find_exactly_one : __find_exactly_one_impl<0,T,Types...>
 // implement std::get()
 namespace std
 {
-
-
-template<size_t i, class... UTypes>
-__TUPLE_ANNOTATION
-typename std::tuple_element<i, __TUPLE_NAMESPACE::tuple<UTypes...>>::type &
-  get(__TUPLE_NAMESPACE::tuple<UTypes...>& t)
-{
-  return t.template mutable_get<i>();
-}
-
-
-template<size_t i, class... UTypes>
-__TUPLE_ANNOTATION
-const typename std::tuple_element<i, __TUPLE_NAMESPACE::tuple<UTypes...>>::type &
-  get(const __TUPLE_NAMESPACE::tuple<UTypes...>& t)
-{
-  return t.template const_get<i>();
-}
-
-
-template<size_t i, class... UTypes>
-__TUPLE_ANNOTATION
-typename std::tuple_element<i, __TUPLE_NAMESPACE::tuple<UTypes...>>::type &&
-  get(__TUPLE_NAMESPACE::tuple<UTypes...>&& t)
-{
-  using type = typename std::tuple_element<i, __TUPLE_NAMESPACE::tuple<UTypes...>>::type;
-
-  auto&& leaf = static_cast<__TUPLE_NAMESPACE::__tuple_leaf<i,type>&&>(t.base());
-
-  return static_cast<type&&>(leaf.mutable_get());
-}
-
 
 template<class T, class... Types>
 __TUPLE_ANNOTATION

--- a/agency/detail/tuple_impl.hpp
+++ b/agency/detail/tuple_impl.hpp
@@ -47,6 +47,71 @@
 #define __TUPLE_NAMESPACE_NEEDS_UNDEF
 #endif
 
+#if defined __NVCC__ && (defined __APPLE__ || defined __MACOSX)
+// Workaround for NVCC bug on OSX
+namespace __nvcc_osx_get_fix
+{
+  template<std::size_t _Int>
+    struct __pair_get;
+
+  template<>
+    struct __pair_get<0>
+    {
+      template<typename _Tp1, typename _Tp2>
+        static constexpr _Tp1&
+        __get(std::pair<_Tp1, _Tp2>& __pair) noexcept
+        { return __pair.first; }
+
+      template<typename _Tp1, typename _Tp2>
+        static constexpr _Tp1&&
+        __move_get(std::pair<_Tp1, _Tp2>&& __pair) noexcept
+        { return std::forward<_Tp1>(__pair.first); }
+
+      template<typename _Tp1, typename _Tp2>
+        static constexpr const _Tp1&
+        __const_get(const std::pair<_Tp1, _Tp2>& __pair) noexcept
+        { return __pair.first; }
+    };
+
+  template<>
+    struct __pair_get<1>
+    {
+      template<typename _Tp1, typename _Tp2>
+        static constexpr _Tp2&
+        __get(std::pair<_Tp1, _Tp2>& __pair) noexcept
+        { return __pair.second; }
+
+      template<typename _Tp1, typename _Tp2>
+        static constexpr _Tp2&&
+        __move_get(std::pair<_Tp1, _Tp2>&& __pair) noexcept
+        { return std::forward<_Tp2>(__pair.second); }
+
+      template<typename _Tp1, typename _Tp2>
+        static constexpr const _Tp2&
+        __const_get(const std::pair<_Tp1, _Tp2>& __pair) noexcept
+        { return __pair.second; }
+    };
+
+  template<std::size_t _Int, class _Tp1, class _Tp2>
+    constexpr typename std::tuple_element<_Int, std::pair<_Tp1, _Tp2>>::type&
+    get(std::pair<_Tp1, _Tp2>& __in) noexcept
+    { return __pair_get<_Int>::__get(__in); }
+
+  template<std::size_t _Int, class _Tp1, class _Tp2>
+    constexpr typename std::tuple_element<_Int, std::pair<_Tp1, _Tp2>>::type&&
+    get(std::pair<_Tp1, _Tp2>&& __in) noexcept
+    { return __pair_get<_Int>::__move_get(std::move(__in)); }
+
+  template<std::size_t _Int, class _Tp1, class _Tp2>
+    constexpr const typename std::tuple_element<_Int, std::pair<_Tp1, _Tp2>>::type&
+    get(const std::pair<_Tp1, _Tp2>& __in) noexcept
+    { return __pair_get<_Int>::__const_get(__in); }
+}
+#define NVCC_OSX_GET_FIX __nvcc_osx_get_fix
+#else
+#define NVCC_OSX_GET_FIX std
+#endif
+
 
 namespace __TUPLE_NAMESPACE
 {
@@ -738,19 +803,19 @@ class tuple
     template<size_t i, class... UTypes>
     friend __TUPLE_ANNOTATION
     typename std::tuple_element<i, __TUPLE_NAMESPACE::tuple<UTypes...>>::type &
-    std::get(__TUPLE_NAMESPACE::tuple<UTypes...>& t);
+    NVCC_OSX_GET_FIX::get(__TUPLE_NAMESPACE::tuple<UTypes...>& t);
 
 
     template<size_t i, class... UTypes>
     friend __TUPLE_ANNOTATION
     const typename std::tuple_element<i, __TUPLE_NAMESPACE::tuple<UTypes...>>::type &
-    std::get(const __TUPLE_NAMESPACE::tuple<UTypes...>& t);
+    NVCC_OSX_GET_FIX::get(const __TUPLE_NAMESPACE::tuple<UTypes...>& t);
 
 
     template<size_t i, class... UTypes>
     friend __TUPLE_ANNOTATION
     typename std::tuple_element<i, __TUPLE_NAMESPACE::tuple<UTypes...>>::type &&
-    std::get(__TUPLE_NAMESPACE::tuple<UTypes...>&& t);
+    NVCC_OSX_GET_FIX::get(__TUPLE_NAMESPACE::tuple<UTypes...>&& t);
 };
 
 
@@ -839,7 +904,7 @@ struct __find_exactly_one : __find_exactly_one_impl<0,T,Types...>
 
 
 // implement std::get()
-namespace std
+namespace NVCC_OSX_GET_FIX
 {
 
 

--- a/agency/detail/tuple_utility_impl.hpp
+++ b/agency/detail/tuple_utility_impl.hpp
@@ -101,21 +101,21 @@ struct tuple_traits
   TUPLE_UTILITY_ANNOTATION
   static element_type<i>& get(tuple_type& t)
   {
-    return std::get<i>(t);
+    return NVCC_OSX_GET_FIX::get<i>(t);
   }
 
   template<size_t i>
   TUPLE_UTILITY_ANNOTATION
   static const element_type<i>& get(const tuple_type& t)
   {
-    return std::get<i>(t);
+    return NVCC_OSX_GET_FIX::get<i>(t);
   }
 
   template<size_t i>
   TUPLE_UTILITY_ANNOTATION
   static element_type<i>&& get(tuple_type&& t)
   {
-    return std::get<i>(std::move(t));
+    return NVCC_OSX_GET_FIX::get<i>(std::move(t));
   }
 };
 

--- a/agency/detail/tuple_utility_impl.hpp
+++ b/agency/detail/tuple_utility_impl.hpp
@@ -101,21 +101,21 @@ struct tuple_traits
   TUPLE_UTILITY_ANNOTATION
   static element_type<i>& get(tuple_type& t)
   {
-    return NVCC_OSX_GET_FIX::get<i>(t);
+    return std::get<i>(t);
   }
 
   template<size_t i>
   TUPLE_UTILITY_ANNOTATION
   static const element_type<i>& get(const tuple_type& t)
   {
-    return NVCC_OSX_GET_FIX::get<i>(t);
+    return std::get<i>(t);
   }
 
   template<size_t i>
   TUPLE_UTILITY_ANNOTATION
   static element_type<i>&& get(tuple_type&& t)
   {
-    return NVCC_OSX_GET_FIX::get<i>(std::move(t));
+    return std::get<i>(std::move(t));
   }
 };
 

--- a/test_shared.cu
+++ b/test_shared.cu
@@ -33,12 +33,7 @@ struct functor
     self.inner().wait();
 
 #if (defined __APPLE__  || defined __MACOSX)
-    /* OSX workaround. 
-     * Presence of assert triggers runtime-error:
-         libc++abi.dylib: terminating with uncaught exception of type thrust::system::detail::bad_alloc: std::bad_alloc: OS call failed or operation not supported on this OS
-         Abort trap: 6
-     */
-    
+    // assert is not supported on OSX, use printf if result is incorrect
     if(!(inner_shared == self.inner().group_size() + 2))
     {
       printf(" -- failure -- : return\n");

--- a/test_shared.cu
+++ b/test_shared.cu
@@ -32,7 +32,21 @@ struct functor
     fetch_and_add(&inner_shared, 1);
     self.inner().wait();
 
+#if (defined __APPLE__  || defined __MACOSX)
+    /* OSX workaround. 
+     * Presence of assert triggers runtime-error:
+         libc++abi.dylib: terminating with uncaught exception of type thrust::system::detail::bad_alloc: std::bad_alloc: OS call failed or operation not supported on this OS
+         Abort trap: 6
+     */
+    
+    if(!(inner_shared == self.inner().group_size() + 2))
+    {
+      printf(" -- failure -- : return\n");
+      return;
+    }
+#else
     assert(inner_shared == self.inner().group_size() + 2);
+#endif
 
     auto result = fetch_and_add(&outer_shared, 1);
 


### PR DESCRIPTION
 * Shamelessly copied part of <utility> from GCC. Seems to fix compilation issues with NVCC on OSX.  
 * Added preprocessor guards to ensure that this workaround is only invoked on OSX with cuda code.

Tried several examples:

OK:

     cuda_grid.cu  
     fill.cu
     multidemensional_agent.cu
     saxpy.cu
     test_concurrent.cu
     test_grid_executor.cu
     test_grid_executor_2d.cu
     test_is_executor.cu
     test_then_execute.cu
     transpose.cu

FAILED:

    test_shared.cu
    $ nvcc test_shared.cu -std=c++11 -I. && ./a.out  
    test_shared.cu(28): warning: argument is incompatible with corresponding format string conversion
    
    test_shared.cu(28): warning: argument is incompatible with corresponding format string conversion
    
    test_shared.cu(28): warning: argument is incompatible with corresponding format string conversion
    
    test_shared.cu(28): warning: argument is incompatible with corresponding format string conversion
    
    libc++abi.dylib: terminating with uncaught exception of type thrust::system::detail::bad_alloc: std::bad_alloc: OS call failed or operation not supported on this OS
    Abort trap: 6

I don't understand this error message yet. Do you perhaps have an idea know which operation  is not yet supported?
   
     
