### PR TITLE
Introduce copy_constructible_function

### DIFF
--- a/agency/detail/executor_traits/copy_constructible_function.hpp
+++ b/agency/detail/executor_traits/copy_constructible_function.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <agency/detail/config.hpp>
+#include <agency/functional.hpp>
+#include <utility>
+#include <memory>
+#include <type_traits>
+
+namespace agency
+{
+namespace detail
+{
+namespace new_executor_traits_detail
+{
+
+
+template<class Function>
+struct shared_function
+{
+  std::shared_ptr<Function> f_ptr;
+
+  template<class Function1,
+           class = typename std::enable_if<
+             std::is_constructible<
+               Function,Function1&&
+             >::value
+           >::type>
+  shared_function(Function1&& f)
+    : f_ptr(std::make_shared<Function>(std::forward<Function1>(f)))
+  {}
+
+  template<class... Args>
+  auto operator()(Args&&... args) ->
+    decltype(agency::invoke(*f_ptr, std::forward<Args>(args)...))
+  {
+    return agency::invoke(*f_ptr, std::forward<Args>(args)...);
+  }
+
+  template<class... Args>
+  auto operator()(Args&&... args) const ->
+    decltype(agency::invoke(*f_ptr, std::forward<Args>(args)...))
+  {
+    return agency::invoke(*f_ptr, std::forward<Args>(args)...);
+  }
+};
+
+
+template<class Function>
+struct copy_constructible_function
+{
+  using type = typename std::conditional<
+    std::is_copy_constructible<Function>::value,
+    Function,
+    shared_function<Function>
+  >::type;
+};
+
+
+template<class Function>
+using copy_constructible_function_t = typename copy_constructible_function<Function>::type;
+
+
+} // end new_executor_traits_detail
+} // end detail
+} // end agency
+

--- a/agency/detail/executor_traits/single_agent_async_execute.hpp
+++ b/agency/detail/executor_traits/single_agent_async_execute.hpp
@@ -5,6 +5,7 @@
 #include <agency/new_executor_traits.hpp>
 #include <agency/detail/executor_traits/check_for_member_functions.hpp>
 #include <type_traits>
+#include <utility>
 
 namespace agency
 {
@@ -18,9 +19,9 @@ template<class Executor, class Function>
 typename new_executor_traits<Executor>::template future<
   typename std::result_of<Function()>::type
 >
-  single_agent_async_execute(std::true_type, Executor& ex, Function f)
+  single_agent_async_execute(std::true_type, Executor& ex, Function&& f)
 {
-  return ex.async_execute(f);
+  return ex.async_execute(std::forward<Function>(f));
 } // end single_agent_async_execute()
 
 
@@ -28,10 +29,10 @@ template<class Executor, class Function>
 typename new_executor_traits<Executor>::template future<
   typename std::result_of<Function()>::type
 >
-  single_agent_async_execute(std::false_type, Executor& ex, Function f)
+  single_agent_async_execute(std::false_type, Executor& ex, Function&& f)
 {
   auto ready = new_executor_traits<Executor>::template make_ready_future<void>(ex);
-  return new_executor_traits<Executor>::then_execute(ex, f, ready);
+  return new_executor_traits<Executor>::then_execute(ex, std::forward<Function>(f), ready);
 } // end single_agent_async_execute()
 
 
@@ -46,14 +47,14 @@ typename new_executor_traits<Executor>::template future<
 >
   new_executor_traits<Executor>
     ::async_execute(typename new_executor_traits<Executor>::executor_type& ex,
-                    Function f)
+                    Function&& f)
 {
   using check_for_member_function = detail::new_executor_traits_detail::has_single_agent_async_execute<
     Executor,
     Function
   >;
 
-  return detail::new_executor_traits_detail::single_agent_async_execute(check_for_member_function(), ex, f);
+  return detail::new_executor_traits_detail::single_agent_async_execute(check_for_member_function(), ex, std::forward<Function>(f));
 } // end new_executor_traits::async_execute()
 
 

--- a/agency/new_executor_traits.hpp
+++ b/agency/new_executor_traits.hpp
@@ -294,7 +294,7 @@ struct new_executor_traits
         typename std::decay<TupleOfFutures>::type
       >
     >
-      when_all_execute_and_select(executor_type& ex, Function f, TupleOfFutures&& futures);
+      when_all_execute_and_select(executor_type& ex, Function&& f, TupleOfFutures&& futures);
 
     // multi-agent when_all_execute_and_select()
     template<size_t... Indices, class Function, class TupleOfFutures>
@@ -322,7 +322,7 @@ struct new_executor_traits
     static future<
       detail::result_of_continuation_t<Function,Future>
     >
-      then_execute(executor_type& ex, Function f, Future& fut);
+      then_execute(executor_type& ex, Function&& f, Future& fut);
 
     // multi-agent then_execute() returning user-specified Container
     template<class Function, class Future, class Factory,
@@ -440,7 +440,7 @@ struct new_executor_traits
     static future<
       typename std::result_of<Function()>::type
     >
-      async_execute(executor_type& ex, Function f);
+      async_execute(executor_type& ex, Function&& f);
 
     // multi-agent async_execute() returning user-specified Container
     template<class Function, class Factory>
@@ -510,7 +510,7 @@ struct new_executor_traits
     // single-agent execute()
     template<class Function>
     static typename std::result_of<Function()>::type
-      execute(executor_type& ex, Function f);
+      execute(executor_type& ex, Function&& f);
 
     // multi-agent execute returning user-specified Container
     template<class Function, class Factory>

--- a/testing/test_single_agent_async_execute.cpp
+++ b/testing/test_single_agent_async_execute.cpp
@@ -4,6 +4,16 @@
 
 #include "test_executors.hpp"
 
+struct move_only
+{
+  std::future<void> f;
+
+  int operator()()
+  {
+    return 13;
+  }
+};
+
 template<class Executor>
 void test()
 {
@@ -36,6 +46,16 @@ void test()
     {
       return 13;
     });
+
+    assert(f.get() == 13);
+    assert(exec.valid());
+  }
+
+  {
+    // with move-only functor
+    executor_type exec;
+
+    auto f = agency::new_executor_traits<executor_type>::async_execute(exec, move_only());
 
     assert(f.get() == 13);
     assert(exec.valid());

--- a/testing/test_single_agent_execute.cpp
+++ b/testing/test_single_agent_execute.cpp
@@ -1,8 +1,19 @@
 #include <agency/new_executor_traits.hpp>
+#include <future>
 #include <cassert>
 #include <iostream>
 
 #include "test_executors.hpp"
+
+struct move_only
+{
+  std::future<void> f;
+
+  int operator()()
+  {
+    return 13;
+  }
+};
 
 template<class Executor>
 void test()
@@ -32,6 +43,16 @@ void test()
     {
       return 13;
     });
+
+    assert(result == 13);
+    assert(exec.valid());
+  }
+
+  {
+    // with move-only functor
+    executor_type exec;
+
+    auto result = agency::new_executor_traits<executor_type>::execute(exec, move_only());
 
     assert(result == 13);
     assert(exec.valid());

--- a/testing/test_single_agent_then_execute.cpp
+++ b/testing/test_single_agent_then_execute.cpp
@@ -4,6 +4,16 @@
 
 #include "test_executors.hpp"
 
+struct move_only
+{
+  std::future<void> f;
+
+  int operator()()
+  {
+    return 13;
+  }
+};
+
 template<class Executor>
 void test()
 {
@@ -78,6 +88,18 @@ void test()
     int_future);
 
     assert(f.get() == 14.f);
+    assert(exec.valid());
+  }
+
+  {
+    // with move-only functor
+    executor_type exec;
+
+    auto void_future = agency::new_executor_traits<executor_type>::template make_ready_future<void>(exec);
+
+    auto f = agency::new_executor_traits<executor_type>::async_execute(exec, move_only());
+
+    assert(f.get() == 13);
     assert(exec.valid());
   }
 }


### PR DESCRIPTION
Use universal references on all single-agent executor_traits functions
to enable perfect forwarding for the function parameter.

Fixes #73