### PR TITLE
Replace "nested_" with "scoped_" when referring to execution

### DIFF
--- a/agency/cuda/execution_policy.hpp
+++ b/agency/cuda/execution_policy.hpp
@@ -7,7 +7,7 @@
 #include <agency/cuda/grid_executor.hpp>
 #include <agency/cuda/parallel_executor.hpp>
 #include <agency/cuda/concurrent_executor.hpp>
-#include <agency/cuda/nested_executor.hpp>
+#include <agency/cuda/scoped_executor.hpp>
 #include <agency/detail/tuple.hpp>
 #include <type_traits>
 
@@ -81,7 +81,7 @@ class parallel_execution_policy : public detail::basic_execution_policy<cuda::pa
 
     // XXX consider whether we really want this functionality a member of parallel_execution_policy
     template<class ExecutionPolicy>
-    agency::detail::nested_execution_policy<
+    agency::detail::scoped_execution_policy<
       par2d_t,
       agency::detail::decay_t<ExecutionPolicy>
     >
@@ -119,7 +119,7 @@ class concurrent_execution_policy : public detail::basic_execution_policy<cuda::
 
     // XXX consider whether we really want this functionality a member of concurrent_execution_policy
     template<class ExecutionPolicy>
-    agency::detail::nested_execution_policy<
+    agency::detail::scoped_execution_policy<
       con2d_t,
       agency::detail::decay_t<ExecutionPolicy>
     >

--- a/agency/cuda/grid_executor.hpp
+++ b/agency/cuda/grid_executor.hpp
@@ -155,7 +155,7 @@ class basic_grid_executor
 
   public:
     using execution_category =
-      nested_execution_tag<
+      scoped_execution_tag<
         parallel_execution_tag,
         concurrent_execution_tag
       >;

--- a/agency/cuda/scoped_executor.hpp
+++ b/agency/cuda/scoped_executor.hpp
@@ -9,7 +9,7 @@ namespace agency
 
 
 template<>
-class nested_executor<cuda::parallel_executor, cuda::block_executor>
+class scoped_executor<cuda::parallel_executor, cuda::block_executor>
   : public cuda::grid_executor
 {
   public:
@@ -18,9 +18,9 @@ class nested_executor<cuda::parallel_executor, cuda::block_executor>
     using outer_executor_type = cuda::parallel_executor;
     using inner_executor_type = cuda::block_executor;
 
-    nested_executor() = default;
+    scoped_executor() = default;
 
-    nested_executor(const outer_executor_type& outer_ex,
+    scoped_executor(const outer_executor_type& outer_ex,
                     const inner_executor_type& inner_ex)
       : outer_ex_(outer_ex),
         inner_ex_(inner_ex)
@@ -49,7 +49,7 @@ class nested_executor<cuda::parallel_executor, cuda::block_executor>
   private:
     outer_executor_type outer_ex_;
     inner_executor_type inner_ex_;
-}; // end nested_executor
+}; // end scoped_executor
 
 
 } // end agency

--- a/agency/detail/bulk_invoke/scope_result.hpp
+++ b/agency/detail/bulk_invoke/scope_result.hpp
@@ -260,10 +260,10 @@ template<class ScopeResult, class Executor, bool Enable = is_scope_result<ScopeR
 struct scope_result_to_scope_result_container
 {
   template<class T>
-  using nested_result_type = typename T::result_type;
+  using member_result_type = typename T::result_type;
 
   // the type returned by the user function
-  using user_result_type = nested_result_type<ScopeResult>;
+  using user_result_type = member_result_type<ScopeResult>;
 
   // the scope at which the result is returned
   static constexpr size_t scope = ScopeResult::scope;

--- a/agency/detail/concurrency/thread_pool.hpp
+++ b/agency/detail/concurrency/thread_pool.hpp
@@ -4,7 +4,7 @@
 #include <agency/execution_categories.hpp>
 #include <agency/parallel_executor.hpp>
 #include <agency/vector_executor.hpp>
-#include <agency/nested_executor.hpp>
+#include <agency/scoped_executor.hpp>
 #include <agency/flattened_executor.hpp>
 #include <agency/detail/concurrency/latch.hpp>
 #include <agency/detail/concurrency/concurrent_queue.hpp>
@@ -211,7 +211,7 @@ class thread_pool_executor
 // compose thread_pool_executor with other fancy executors
 // to yield a parallel_thread_pool_executor
 using parallel_thread_pool_executor = agency::flattened_executor<
-  agency::nested_executor<
+  agency::scoped_executor<
     thread_pool_executor,
     agency::this_thread::parallel_executor
   >
@@ -221,7 +221,7 @@ using parallel_thread_pool_executor = agency::flattened_executor<
 // compose thread_pool_executor with other fancy executors
 // to yield a parallel_vector_thread_pool_executor
 using parallel_vector_thread_pool_executor = agency::flattened_executor<
-  agency::nested_executor<
+  agency::scoped_executor<
     thread_pool_executor,
     agency::this_thread::vector_executor
   >

--- a/agency/detail/execution_policy_traits.hpp
+++ b/agency/detail/execution_policy_traits.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <agency/detail/config.hpp>
 #include <agency/executor_traits.hpp>
+#include <agency/detail/has_member.hpp>
 
 namespace agency
 {
@@ -8,7 +10,7 @@ namespace detail
 {
 
 
-__DEFINE_HAS_NESTED_TYPE(has_executor_type, executor_type);
+__DEFINE_HAS_MEMBER_TYPE(has_executor_type, executor_type);
 
 
 template<class ExecutionPolicy, class Enable = void>
@@ -37,7 +39,7 @@ template<class ExecutionPolicy, class T>
 using policy_future_t = typename policy_future<ExecutionPolicy,T>::type;
 
 
-__DEFINE_HAS_NESTED_TYPE(has_execution_agent_type, execution_agent_type);
+__DEFINE_HAS_MEMBER_TYPE(has_execution_agent_type, execution_agent_type);
 
 
 template<class ExecutionPolicy, class Enable = void>

--- a/agency/detail/executor_traits/member_types.hpp
+++ b/agency/detail/executor_traits/member_types.hpp
@@ -12,10 +12,10 @@ namespace executor_traits_detail
 {
 
 
-__DEFINE_HAS_NESTED_TYPE(has_execution_category, execution_category);
-__DEFINE_HAS_NESTED_TYPE(has_index_type, index_type);
-__DEFINE_HAS_NESTED_TYPE(has_shape_type, shape_type);
-__DEFINE_HAS_NESTED_CLASS_TEMPLATE(has_container_template, container);
+__DEFINE_HAS_MEMBER_TYPE(has_execution_category, execution_category);
+__DEFINE_HAS_MEMBER_TYPE(has_index_type, index_type);
+__DEFINE_HAS_MEMBER_TYPE(has_shape_type, shape_type);
+__DEFINE_HAS_MEMBER_CLASS_TEMPLATE(has_container_template, container);
 
 
 template<class T, class Index>
@@ -45,51 +45,51 @@ using is_container = typename is_container_impl<T,Index>::type;
 
 
 template<class T>
-struct nested_execution_category
+struct member_execution_category
 {
   using type = typename T::execution_category;
 };
 
 
 template<class T, class Default = parallel_execution_tag>
-struct nested_execution_category_with_default
+struct member_execution_category_with_default
   : agency::detail::lazy_conditional<
       has_execution_category<T>::value,
-      nested_execution_category<T>,
+      member_execution_category<T>,
       agency::detail::identity<Default>
     >
 {};
 
 
 template<class T>
-struct nested_index_type
+struct member_index_type
 {
   using type = typename T::index_type;
 };
 
 
 template<class T, class Default = size_t>
-struct nested_index_type_with_default
+struct member_index_type_with_default
   : agency::detail::lazy_conditional<
       has_index_type<T>::value,
-      nested_index_type<T>,
+      member_index_type<T>,
       agency::detail::identity<Default>
     >
 {};
 
 
 template<class T>
-struct nested_shape_type
+struct member_shape_type
 {
   using type = typename T::shape_type;
 };
 
 
 template<class T, class Default = size_t>
-struct nested_shape_type_with_default
+struct member_shape_type_with_default
   : agency::detail::lazy_conditional<
       has_shape_type<T>::value,
-      nested_shape_type<T>,
+      member_shape_type<T>,
       agency::detail::identity<Default>
     >
 {};
@@ -248,7 +248,7 @@ struct identity_template
 
 
 template<class Executor>
-using executor_execution_category_t = typename nested_execution_category_with_default<
+using executor_execution_category_t = typename member_execution_category_with_default<
   Executor,
   parallel_execution_tag
 >::type;
@@ -275,7 +275,7 @@ using executor_shape_t = typename executor_shape<Executor>::type;
 
 
 template<class Executor>
-using executor_index_t = typename nested_index_type_with_default<
+using executor_index_t = typename member_index_type_with_default<
   Executor,
   executor_shape_t<Executor>
 >::type;

--- a/agency/detail/has_member.hpp
+++ b/agency/detail/has_member.hpp
@@ -2,51 +2,51 @@
 
 #include <agency/detail/config.hpp>
 
-#define __DEFINE_HAS_NESTED_TYPE(trait_name, nested_type_name) \
+#define __DEFINE_HAS_MEMBER_TYPE(trait_name, member_type_name) \
 template<typename T> \
   struct trait_name  \
 {                    \
   typedef char yes_type; \
   typedef int  no_type;  \
-  template<typename S> static yes_type test(typename S::nested_type_name *); \
+  template<typename S> static yes_type test(typename S::member_type_name *); \
   template<typename S> static no_type  test(...); \
   static bool const value = sizeof(test<T>(0)) == sizeof(yes_type);\
   typedef std::integral_constant<bool, value> type;\
 };
 
-#define __DEFINE_HAS_NESTED_CLASS_TEMPLATE(trait_name, nested_class_template_name) \
+#define __DEFINE_HAS_MEMBER_CLASS_TEMPLATE(trait_name, member_class_template_name) \
 template<typename T, typename... Types> \
   struct trait_name         \
 {                           \
   typedef char yes_type;    \
   typedef int  no_type;     \
-  template<typename S> static yes_type test(typename S::template nested_class_template_name<Types...> *); \
+  template<typename S> static yes_type test(typename S::template member_class_template_name<Types...> *); \
   template<typename S> static no_type  test(...); \
   static bool const value = sizeof(test<T>(0)) == sizeof(yes_type);\
   typedef std::integral_constant<bool, value> type;\
 };
 
 #ifdef __NVCC__
-#define __DEFINE_HAS_NESTED_MEMBER(trait_name, nested_member_name) \
+#define __DEFINE_HAS_MEMBER(trait_name, member_name) \
 template<typename T> \
   struct trait_name  \
 {                    \
   typedef char yes_type; \
   typedef int  no_type;  \
   template<int i> struct swallow_int {}; \
-  template<typename S> static yes_type test(swallow_int<sizeof(S::nested_member_name)>*); \
+  template<typename S> static yes_type test(swallow_int<sizeof(S::member_name)>*); \
   template<typename S> static no_type  test(...); \
   static bool const value = sizeof(test<T>(0)) == sizeof(yes_type);\
   typedef std::integral_constant<bool, value> type;\
 };
 #else
-#define __DEFINE_HAS_NESTED_MEMBER(trait_name, nested_member_name) \
+#define __DEFINE_HAS_MEMBER(trait_name, member_name) \
 template<typename T> \
   struct trait_name  \
 {                    \
   typedef char yes_type; \
   typedef int  no_type;  \
-  template<typename S> static yes_type test(decltype(S::nested_member_name)*); \
+  template<typename S> static yes_type test(decltype(S::member_name)*); \
   template<typename S> static no_type  test(...); \
   static bool const value = sizeof(test<T>(0)) == sizeof(yes_type);\
   typedef std::integral_constant<bool, value> type;\

--- a/agency/detail/index_tuple.hpp
+++ b/agency/detail/index_tuple.hpp
@@ -4,7 +4,7 @@
 #include <agency/detail/tuple.hpp>
 #include <agency/detail/arithmetic_tuple_facade.hpp>
 #include <agency/detail/type_traits.hpp>
-#include <agency/detail/make_tuple_if_not_nested.hpp>
+#include <agency/detail/make_tuple_if_not_scoped.hpp>
 
 namespace agency
 {
@@ -57,13 +57,13 @@ template<class ExecutionCategory1,
          class ExecutionCategory2,
          class Index1,
          class Index2>
-struct nested_index
+struct scoped_index
 {
   using type = decltype(
     __tu::tuple_cat_apply(
       detail::index_tuple_maker{},
-      detail::make_tuple_if_not_nested<ExecutionCategory1>(std::declval<Index1>()),
-      detail::make_tuple_if_not_nested<ExecutionCategory2>(std::declval<Index2>())
+      detail::make_tuple_if_not_scoped<ExecutionCategory1>(std::declval<Index1>()),
+      detail::make_tuple_if_not_scoped<ExecutionCategory2>(std::declval<Index2>())
     )
   );
 };
@@ -73,7 +73,7 @@ template<class ExecutionCategory1,
          class ExecutionCategory2,
          class Index1,
          class Index2>
-using nested_index_t = typename nested_index<
+using scoped_index_t = typename scoped_index<
   ExecutionCategory1,
   ExecutionCategory2,
   Index1,
@@ -86,12 +86,12 @@ template<class ExecutionCategory1,
          class Index1,
          class Index2>
 __AGENCY_ANNOTATION
-nested_index_t<ExecutionCategory1,ExecutionCategory2,Index1,Index2> make_nested_index(const Index1& outer_idx, const Index2& inner_idx)
+scoped_index_t<ExecutionCategory1,ExecutionCategory2,Index1,Index2> make_scoped_index(const Index1& outer_idx, const Index2& inner_idx)
 {
   return __tu::tuple_cat_apply(
     detail::index_tuple_maker{},
-    detail::make_tuple_if_not_nested<ExecutionCategory1>(outer_idx),
-    detail::make_tuple_if_not_nested<ExecutionCategory2>(inner_idx)
+    detail::make_tuple_if_not_scoped<ExecutionCategory1>(outer_idx),
+    detail::make_tuple_if_not_scoped<ExecutionCategory2>(inner_idx)
   );
 }
 

--- a/agency/detail/is_call_possible.hpp
+++ b/agency/detail/is_call_possible.hpp
@@ -10,7 +10,7 @@ namespace detail
 
 
 template<typename T>
-  struct has_nested_type_impl
+  struct has_member_type_impl
 {                    
   typedef char yes_type;
   typedef int  no_type;
@@ -22,12 +22,12 @@ template<typename T>
 
 
 template<class T>
-struct has_nested_type : has_nested_type_impl<T>::type {};
+struct has_member_type : has_member_type_impl<T>::type {};
 
 
 template<class Function, class... Args>
 struct is_call_possible
-  : has_nested_type<
+  : has_member_type<
       std::result_of<Function(Args...)>
     >
 {

--- a/agency/detail/make_tuple_if_not_scoped.hpp
+++ b/agency/detail/make_tuple_if_not_scoped.hpp
@@ -11,19 +11,19 @@ namespace detail
 {
 
 
-// execution is nested, just return x
+// execution is scoped, just return x
 template<class ExecutionCategory1, class ExecutionCategory2, class T>
 __AGENCY_ANNOTATION
-T make_tuple_if_not_nested(agency::nested_execution_tag<ExecutionCategory1,ExecutionCategory2>, const T& x)
+T make_tuple_if_not_scoped(agency::scoped_execution_tag<ExecutionCategory1,ExecutionCategory2>, const T& x)
 {
   return x;
 }
 
 
-// execution is not nested, wrap up x in a tuple
+// execution is not scoped, wrap up x in a tuple
 template<class ExecutionCategory, class T>
 __AGENCY_ANNOTATION
-agency::detail::tuple<T> make_tuple_if_not_nested(ExecutionCategory, const T& x)
+agency::detail::tuple<T> make_tuple_if_not_scoped(ExecutionCategory, const T& x)
 {
   return agency::detail::make_tuple(x);
 }
@@ -31,16 +31,16 @@ agency::detail::tuple<T> make_tuple_if_not_nested(ExecutionCategory, const T& x)
 
 template<class ExecutionCategory, class T>
 __AGENCY_ANNOTATION
-auto make_tuple_if_not_nested(const T& x)
-  -> decltype(agency::detail::make_tuple_if_not_nested(ExecutionCategory(), x))
+auto make_tuple_if_not_scoped(const T& x)
+  -> decltype(agency::detail::make_tuple_if_not_scoped(ExecutionCategory(), x))
 {
-  return agency::detail::make_tuple_if_not_nested(ExecutionCategory(), x);
+  return agency::detail::make_tuple_if_not_scoped(ExecutionCategory(), x);
 }
 
 
 template<class ExecutionCategory1, class ExecutionCategory2, class T>
 __AGENCY_ANNOTATION
-auto tie_if_not_nested(nested_execution_tag<ExecutionCategory1,ExecutionCategory2>, T&& x)
+auto tie_if_not_scoped(scoped_execution_tag<ExecutionCategory1,ExecutionCategory2>, T&& x)
   -> decltype(std::forward<T>(x))
 {
   return std::forward<T>(x);
@@ -49,7 +49,7 @@ auto tie_if_not_nested(nested_execution_tag<ExecutionCategory1,ExecutionCategory
 
 template<class ExecutionCategory, class T>
 __AGENCY_ANNOTATION
-auto tie_if_not_nested(ExecutionCategory, T&& x)
+auto tie_if_not_scoped(ExecutionCategory, T&& x)
   -> decltype(agency::detail::tie(std::forward<T>(x)))
 {
   return agency::detail::tie(std::forward<T>(x));
@@ -58,10 +58,10 @@ auto tie_if_not_nested(ExecutionCategory, T&& x)
 
 template<class ExecutionCategory, class T>
 __AGENCY_ANNOTATION
-auto tie_if_not_nested(T&& x)
-  -> decltype(tie_if_not_nested(ExecutionCategory(), std::forward<T>(x)))
+auto tie_if_not_scoped(T&& x)
+  -> decltype(tie_if_not_scoped(ExecutionCategory(), std::forward<T>(x)))
 {
-  return tie_if_not_nested(ExecutionCategory(), std::forward<T>(x));
+  return tie_if_not_scoped(ExecutionCategory(), std::forward<T>(x));
 }
 
 

--- a/agency/detail/shape_tuple.hpp
+++ b/agency/detail/shape_tuple.hpp
@@ -4,7 +4,7 @@
 #include <agency/detail/tuple.hpp>
 #include <agency/detail/arithmetic_tuple_facade.hpp>
 #include <agency/detail/type_traits.hpp>
-#include <agency/detail/make_tuple_if_not_nested.hpp>
+#include <agency/detail/make_tuple_if_not_scoped.hpp>
 
 namespace agency
 {
@@ -27,12 +27,12 @@ template<class ExecutionCategory1,
          class ExecutionCategory2,
          class Shape1,
          class Shape2>
-struct nested_shape
+struct scoped_shape
 {
   using type = decltype(
     detail::tuple_cat(
-      detail::make_tuple_if_not_nested<ExecutionCategory1>(std::declval<Shape1>()),
-      detail::make_tuple_if_not_nested<ExecutionCategory2>(std::declval<Shape2>())
+      detail::make_tuple_if_not_scoped<ExecutionCategory1>(std::declval<Shape1>()),
+      detail::make_tuple_if_not_scoped<ExecutionCategory2>(std::declval<Shape2>())
     )
   );
 };
@@ -42,7 +42,7 @@ template<class ExecutionCategory1,
          class ExecutionCategory2,
          class Shape1,
          class Shape2>
-using nested_shape_t = typename nested_shape<
+using scoped_shape_t = typename scoped_shape<
   ExecutionCategory1,
   ExecutionCategory2,
   Shape1,
@@ -55,11 +55,11 @@ template<class ExecutionCategory1,
          class Shape1,
          class Shape2>
 __AGENCY_ANNOTATION
-nested_shape_t<ExecutionCategory1,ExecutionCategory2,Shape1,Shape2> make_nested_shape(const Shape1& outer_shape, const Shape2& inner_shape)
+scoped_shape_t<ExecutionCategory1,ExecutionCategory2,Shape1,Shape2> make_scoped_shape(const Shape1& outer_shape, const Shape2& inner_shape)
 {
   return detail::tuple_cat(
-    detail::make_tuple_if_not_nested<ExecutionCategory1>(outer_shape),
-    detail::make_tuple_if_not_nested<ExecutionCategory2>(inner_shape)
+    detail::make_tuple_if_not_scoped<ExecutionCategory1>(outer_shape),
+    detail::make_tuple_if_not_scoped<ExecutionCategory2>(inner_shape)
   );
 }
 

--- a/agency/detail/tuple.hpp
+++ b/agency/detail/tuple.hpp
@@ -11,7 +11,7 @@
 #include <agency/detail/integer_sequence.hpp>
 #include <agency/detail/type_list.hpp>
 #include <agency/detail/host_device_cast.hpp>
-#include <agency/detail/has_nested.hpp>
+#include <agency/detail/has_member.hpp>
 #include <agency/detail/type_traits.hpp>
 #include <utility>
 #include <type_traits>
@@ -52,7 +52,7 @@ using ignore_t = decltype(__tu::ignore);
 constexpr ignore_t ignore{};
 
 
-__DEFINE_HAS_NESTED_MEMBER(has_value, value);
+__DEFINE_HAS_MEMBER(has_value, value);
 
 
 template<class T>

--- a/agency/detail/unwrap_tuple_if_not_scoped.hpp
+++ b/agency/detail/unwrap_tuple_if_not_scoped.hpp
@@ -12,7 +12,7 @@ namespace detail
 
 template<class ExecutionCategory, class Tuple>
 __AGENCY_ANNOTATION
-static auto unwrap_tuple_if_not_nested_impl(ExecutionCategory, Tuple&& t)
+static auto unwrap_tuple_if_not_scoped_impl(ExecutionCategory, Tuple&& t)
   -> decltype(detail::get<0>(std::forward<Tuple>(t)))
 {
   return detail::get<0>(std::forward<Tuple>(t));
@@ -20,7 +20,7 @@ static auto unwrap_tuple_if_not_nested_impl(ExecutionCategory, Tuple&& t)
 
 template<class ExecutionCategory1, class ExecutionCategory2, class Tuple>
 __AGENCY_ANNOTATION
-static auto unwrap_tuple_if_not_nested_impl(nested_execution_tag<ExecutionCategory1,ExecutionCategory2>, Tuple&& t)
+static auto unwrap_tuple_if_not_scoped_impl(scoped_execution_tag<ExecutionCategory1,ExecutionCategory2>, Tuple&& t)
   -> decltype(std::forward<Tuple>(t))
 {
   return std::forward<Tuple>(t);
@@ -29,12 +29,12 @@ static auto unwrap_tuple_if_not_nested_impl(nested_execution_tag<ExecutionCatego
 
 template<class ExecutionCategory, class Tuple>
 __AGENCY_ANNOTATION
-auto unwrap_tuple_if_not_nested(Tuple&& t)
+auto unwrap_tuple_if_not_scoped(Tuple&& t)
   -> decltype(
-       unwrap_tuple_if_not_nested_impl(ExecutionCategory(), std::forward<Tuple>(t))
+       unwrap_tuple_if_not_scoped_impl(ExecutionCategory(), std::forward<Tuple>(t))
      )
 {
-  return unwrap_tuple_if_not_nested_impl(ExecutionCategory(), std::forward<Tuple>(t));
+  return unwrap_tuple_if_not_scoped_impl(ExecutionCategory(), std::forward<Tuple>(t));
 }
 
 

--- a/agency/execution_agent.hpp
+++ b/agency/execution_agent.hpp
@@ -5,8 +5,8 @@
 #include <agency/detail/tuple.hpp>
 #include <agency/detail/type_traits.hpp>
 #include <agency/detail/index_tuple.hpp>
-#include <agency/detail/unwrap_tuple_if_not_nested.hpp>
-#include <agency/detail/make_tuple_if_not_nested.hpp>
+#include <agency/detail/unwrap_tuple_if_not_scoped.hpp>
+#include <agency/detail/make_tuple_if_not_scoped.hpp>
 #include <agency/coordinate.hpp>
 #include <type_traits>
 
@@ -16,9 +16,9 @@ namespace detail
 {
 
 
-__DEFINE_HAS_NESTED_TYPE(has_param_type, param_type);
-__DEFINE_HAS_NESTED_TYPE(has_shared_param_type, shared_param_type);
-__DEFINE_HAS_NESTED_TYPE(has_inner_execution_agent_type, inner_execution_agent_type);
+__DEFINE_HAS_MEMBER_TYPE(has_param_type, param_type);
+__DEFINE_HAS_MEMBER_TYPE(has_shared_param_type, shared_param_type);
+__DEFINE_HAS_MEMBER_TYPE(has_inner_execution_agent_type, inner_execution_agent_type);
 
 
 template<class ExecutionAgent, class Enable = void>
@@ -321,7 +321,7 @@ struct execution_agent_traits : detail::execution_agent_traits_base<ExecutionAge
     }
 
 
-    // default case for nested agents
+    // default case for scoped agents
     template<class ExecutionAgent1>
     __AGENCY_ANNOTATION
     static shared_param_tuple_type make_shared_param_tuple_default_impl(const param_type& param, std::true_type)
@@ -584,8 +584,8 @@ class execution_group : public execution_group_base<OuterExecutionAgent>
     using index_type = decltype(
       __tu::tuple_cat_apply(
         agency::detail::index_tuple_maker{},
-        agency::detail::make_tuple_if_not_nested<outer_execution_category>(std::declval<outer_index_type>()),
-        agency::detail::make_tuple_if_not_nested<inner_execution_category>(std::declval<inner_index_type>())
+        agency::detail::make_tuple_if_not_scoped<outer_execution_category>(std::declval<outer_index_type>()),
+        agency::detail::make_tuple_if_not_scoped<inner_execution_category>(std::declval<inner_index_type>())
       )
     );
 
@@ -598,13 +598,13 @@ class execution_group : public execution_group_base<OuterExecutionAgent>
     {
       return __tu::tuple_cat_apply(
         agency::detail::index_tuple_maker{},
-        agency::detail::make_tuple_if_not_nested<outer_execution_category>(outer_idx),
-        agency::detail::make_tuple_if_not_nested<inner_execution_category>(inner_idx)
+        agency::detail::make_tuple_if_not_scoped<outer_execution_category>(outer_idx),
+        agency::detail::make_tuple_if_not_scoped<inner_execution_category>(inner_idx)
       );
     }
 
   public:
-    using execution_category = nested_execution_tag<
+    using execution_category = scoped_execution_tag<
       outer_execution_category,
       inner_execution_category
     >;
@@ -733,7 +733,7 @@ class execution_group : public execution_group_base<OuterExecutionAgent>
     __AGENCY_ANNOTATION
     static inner_index_type inner_index(const index_type& index)
     {
-      return detail::unwrap_tuple_if_not_nested<inner_execution_category>(detail::forward_tail(index));
+      return detail::unwrap_tuple_if_not_scoped<inner_execution_category>(detail::forward_tail(index));
     }
 
     outer_execution_agent_type outer_agent_;

--- a/agency/execution_categories.hpp
+++ b/agency/execution_categories.hpp
@@ -15,7 +15,7 @@ struct vector_execution_tag {};
 
 
 template<class ExecutionCategory1, class ExecutionCategory2>
-struct nested_execution_tag
+struct scoped_execution_tag
 {
   using outer_execution_category = ExecutionCategory1;
   using inner_execution_category = ExecutionCategory2;
@@ -38,7 +38,7 @@ struct nested_execution_tag
 //
 // XXX figure out how sequential is related to concurrent
 //
-// XXX figure out how nested_execution_tag sorts
+// XXX figure out how scoped_execution_tag sorts
 
 
 namespace detail
@@ -46,11 +46,11 @@ namespace detail
 
 
 template<class ExecutionCategory>
-struct is_nested_execution_category : std::false_type {};
+struct is_scoped_execution_category : std::false_type {};
 
 
 template<class ExecutionCategory1, class ExecutionCategory2>
-struct is_nested_execution_category<nested_execution_tag<ExecutionCategory1,ExecutionCategory2>> : std::true_type {};
+struct is_scoped_execution_category<scoped_execution_tag<ExecutionCategory1,ExecutionCategory2>> : std::true_type {};
 
 
 template<class ExecutionCategory>
@@ -58,7 +58,7 @@ struct execution_depth : std::integral_constant<size_t, 1> {};
 
 
 template<class ExecutionCategory1, class ExecutionCategory2>
-struct execution_depth<nested_execution_tag<ExecutionCategory1,ExecutionCategory2>>
+struct execution_depth<scoped_execution_tag<ExecutionCategory1,ExecutionCategory2>>
   : std::integral_constant<
       size_t,
       1 + execution_depth<ExecutionCategory2>::value

--- a/agency/executor_array.hpp
+++ b/agency/executor_array.hpp
@@ -29,7 +29,7 @@ class executor_array
     constexpr static size_t inner_depth = inner_traits::execution_depth;
 
   public:
-    using execution_category = nested_execution_tag<outer_execution_category,inner_execution_category>;
+    using execution_category = scoped_execution_tag<outer_execution_category,inner_execution_category>;
 
     using outer_shape_type = typename outer_traits::shape_type;
     using inner_shape_type = typename inner_traits::shape_type;
@@ -37,13 +37,13 @@ class executor_array
     using outer_index_type = typename outer_traits::index_type;
     using inner_index_type = typename inner_traits::index_type;
 
-    using shape_type = detail::nested_shape_t<outer_execution_category,inner_execution_category,outer_shape_type,inner_shape_type>;
-    using index_type = detail::nested_index_t<outer_execution_category,inner_execution_category,outer_index_type,inner_index_type>;
+    using shape_type = detail::scoped_shape_t<outer_execution_category,inner_execution_category,outer_shape_type,inner_shape_type>;
+    using index_type = detail::scoped_index_t<outer_execution_category,inner_execution_category,outer_index_type,inner_index_type>;
 
     __AGENCY_ANNOTATION
     static shape_type make_shape(const outer_shape_type& outer_shape, const inner_shape_type& inner_shape)
     {
-      return detail::make_nested_shape<outer_execution_category,inner_execution_category>(outer_shape, inner_shape);
+      return detail::make_scoped_shape<outer_execution_category,inner_execution_category>(outer_shape, inner_shape);
     }
 
     __agency_exec_check_disable__
@@ -121,7 +121,7 @@ class executor_array
     __AGENCY_ANNOTATION
     static index_type make_index(const outer_index_type& outer_idx, const inner_index_type& inner_idx)
     {
-      return detail::make_nested_index<outer_execution_category,inner_execution_category>(outer_idx, inner_idx);
+      return detail::make_scoped_index<outer_execution_category,inner_execution_category>(outer_idx, inner_idx);
     }
 
     __AGENCY_ANNOTATION

--- a/agency/flattened_executor.hpp
+++ b/agency/flattened_executor.hpp
@@ -4,7 +4,7 @@
 #include <agency/detail/tuple.hpp>
 #include <agency/executor_traits.hpp>
 #include <agency/execution_categories.hpp>
-#include <agency/nested_executor.hpp>
+#include <agency/scoped_executor.hpp>
 #include <agency/detail/factory.hpp>
 #include <agency/detail/optional.hpp>
 #include <agency/detail/flatten_index_and_invoke.hpp>
@@ -88,17 +88,17 @@ template<class ExecutionCategory>
 struct flattened_execution_tag_impl;
 
 template<class OuterCategory, class InnerCategory>
-struct flattened_execution_tag_impl<nested_execution_tag<OuterCategory,InnerCategory>>
+struct flattened_execution_tag_impl<scoped_execution_tag<OuterCategory,InnerCategory>>
 {
   using type = parallel_execution_tag;
 };
 
 template<class OuterCategory, class InnerCategory, class InnerInnerCategory>
-struct flattened_execution_tag_impl<nested_execution_tag<OuterCategory, nested_execution_tag<InnerCategory,InnerInnerCategory>>>
+struct flattened_execution_tag_impl<scoped_execution_tag<OuterCategory, scoped_execution_tag<InnerCategory,InnerInnerCategory>>>
 {
   // OuterCategory and InnerInnerCategory merge into parallel as the outer category
   // while InnerInnerCategory is promoted to the inner category
-  using type = nested_execution_tag<
+  using type = scoped_execution_tag<
     parallel_execution_tag,
     InnerInnerCategory
   >;
@@ -114,10 +114,10 @@ using flattened_execution_tag = typename flattened_execution_tag_impl<ExecutionC
 template<class Executor>
 class flattened_executor
 {
-  // probably shouldn't insist on a nested executor
+  // probably shouldn't insist on a scoped executor
   static_assert(
-    detail::is_nested_execution_category<typename executor_traits<Executor>::execution_category>::value,
-    "Execution category of Executor must be nested."
+    detail::is_scoped_execution_category<typename executor_traits<Executor>::execution_category>::value,
+    "Execution category of Executor must be scoped."
   );
 
   private:

--- a/agency/future.hpp
+++ b/agency/future.hpp
@@ -250,7 +250,7 @@ struct rebind_future_value<Future<FromType>,ToType>
 };
 
 
-__DEFINE_HAS_NESTED_TYPE(has_value_type, value_type);
+__DEFINE_HAS_MEMBER_TYPE(has_value_type, value_type);
 
 
 template<class Future>

--- a/agency/scoped_executor.hpp
+++ b/agency/scoped_executor.hpp
@@ -7,9 +7,8 @@ namespace agency
 {
 
 
-// XXX we should rename this to something like scoped_executor
 template<class Executor1, class Executor2>
-class nested_executor : public executor_array<Executor2,Executor1>
+class scoped_executor : public executor_array<Executor2,Executor1>
 {
   private:
     using super_t = executor_array<Executor2,Executor1>;
@@ -18,13 +17,13 @@ class nested_executor : public executor_array<Executor2,Executor1>
     using outer_executor_type = Executor1;
     using inner_executor_type = Executor2;
 
-    nested_executor(const outer_executor_type&,
+    scoped_executor(const outer_executor_type&,
                     const inner_executor_type& inner_ex)
       : super_t(1, inner_ex)
     {}
 
-    nested_executor() :
-      nested_executor(outer_executor_type(), inner_executor_type())
+    scoped_executor() :
+      scoped_executor(outer_executor_type(), inner_executor_type())
     {}
 };
 

--- a/test_is_executor.cpp
+++ b/test_is_executor.cpp
@@ -2,7 +2,7 @@
 #include <agency/concurrent_executor.hpp>
 #include <agency/parallel_executor.hpp>
 #include <agency/vector_executor.hpp>
-#include <agency/nested_executor.hpp>
+#include <agency/scoped_executor.hpp>
 #include <agency/executor_traits.hpp>
 #include <iostream>
 
@@ -22,8 +22,8 @@ int main()
   std::cout << "is_executor<agency::parallel_executor>: " << agency::is_executor<agency::parallel_executor>::value << std::endl;
   std::cout << "has_then_execute<agency::parallel_executor>: " << has_any_multi_agent_then_execute<agency::parallel_executor>::value << std::endl;
 
-  std::cout << "is_executor<agency::nested_executor<agency::concurrent_executor,agency::sequential_executor>>: " << agency::is_executor<agency::nested_executor<agency::concurrent_executor,agency::sequential_executor>>::value << std::endl;
-  std::cout << "has_then_execute<agency::nested_executor<agency::concurrent_executor,agency::sequential_executor>>: " << has_any_multi_agent_then_execute<agency::nested_executor<agency::concurrent_executor,agency::sequential_executor>>::value << std::endl;
+  std::cout << "is_executor<agency::scoped_executor<agency::concurrent_executor,agency::sequential_executor>>: " << agency::is_executor<agency::scoped_executor<agency::concurrent_executor,agency::sequential_executor>>::value << std::endl;
+  std::cout << "has_then_execute<agency::scoped_executor<agency::concurrent_executor,agency::sequential_executor>>: " << has_any_multi_agent_then_execute<agency::scoped_executor<agency::concurrent_executor,agency::sequential_executor>>::value << std::endl;
 
   return 0;
 }

--- a/test_is_executor.cu
+++ b/test_is_executor.cu
@@ -3,7 +3,7 @@
 #include <agency/flattened_executor.hpp>
 #include <agency/cuda/parallel_executor.hpp>
 #include <agency/cuda/concurrent_executor.hpp>
-#include <agency/nested_executor.hpp>
+#include <agency/scoped_executor.hpp>
 #include <agency/concurrent_executor.hpp>
 #include <agency/sequential_executor.hpp>
 #include <agency/parallel_executor.hpp>
@@ -23,8 +23,8 @@ int main()
   std::cout << "is_executor<agency::parallel_executor>: " << agency::is_executor<agency::parallel_executor>::value << std::endl;
   std::cout << "has_then_execute<agency::parallel_executor>: " << has_any_multi_agent_then_execute<agency::parallel_executor>::value << std::endl;
 
-  std::cout << "is_executor<agency::nested_executor<agency::concurrent_executor,agency::sequential_executor>>: " << agency::is_executor<agency::nested_executor<agency::concurrent_executor,agency::sequential_executor>>::value << std::endl;
-  std::cout << "has_then_execute<agency::nested_executor<agency::concurrent_executor,agency::sequential_executor>>: " << has_any_multi_agent_then_execute<agency::nested_executor<agency::concurrent_executor,agency::sequential_executor>>::value << std::endl;
+  std::cout << "is_executor<agency::scoped_executor<agency::concurrent_executor,agency::sequential_executor>>: " << agency::is_executor<agency::scoped_executor<agency::concurrent_executor,agency::sequential_executor>>::value << std::endl;
+  std::cout << "has_then_execute<agency::scoped_executor<agency::concurrent_executor,agency::sequential_executor>>: " << has_any_multi_agent_then_execute<agency::scoped_executor<agency::concurrent_executor,agency::sequential_executor>>::value << std::endl;
 
 
   std::cout << "is_executor<grid_executor>: " << agency::is_executor<agency::cuda::grid_executor>::value << std::endl;

--- a/test_scoped_executor.hpp
+++ b/test_scoped_executor.hpp
@@ -1,4 +1,4 @@
-#include <agency/nested_executor.hpp>
+#include <agency/scoped_executor.hpp>
 #include <agency/concurrent_executor.hpp>
 #include <agency/sequential_executor.hpp>
 #include <agency/bulk_invoke.hpp>
@@ -13,7 +13,7 @@ int main()
   // XXX we should really assert that the results match the expected value
 
   {
-    using executor_type = agency::nested_executor<agency::concurrent_executor, agency::sequential_executor>;
+    using executor_type = agency::scoped_executor<agency::concurrent_executor, agency::sequential_executor>;
     executor_type ex;
 
     using traits = agency::executor_traits<executor_type>;
@@ -67,7 +67,7 @@ int main()
   {
     // test with 3-deep nesting
     
-    using executor_type = agency::nested_executor<agency::sequential_executor, agency::nested_executor<agency::sequential_executor,agency::sequential_executor>>;
+    using executor_type = agency::scoped_executor<agency::sequential_executor, agency::scoped_executor<agency::sequential_executor,agency::sequential_executor>>;
     using traits = agency::executor_traits<executor_type>;
     executor_type ex;
 

--- a/test_shared.cpp
+++ b/test_shared.cpp
@@ -95,9 +95,9 @@ size_t rank(agency::size3 shape, agency::size3 idx)
 
 void test1()
 {
-  using executor_type1 = agency::nested_executor<agency::sequential_executor,agency::sequential_executor>;
+  using executor_type1 = agency::scoped_executor<agency::sequential_executor,agency::sequential_executor>;
 
-  using executor_type2 = agency::nested_executor<agency::sequential_executor,executor_type1>;
+  using executor_type2 = agency::scoped_executor<agency::sequential_executor,executor_type1>;
 
   executor_type2 exec;
   executor_type2::shape_type shape{2,2,2};

--- a/test_then_execute.cpp
+++ b/test_then_execute.cpp
@@ -2,7 +2,7 @@
 #include <agency/sequential_executor.hpp>
 #include <agency/concurrent_executor.hpp>
 #include <agency/parallel_executor.hpp>
-#include <agency/nested_executor.hpp>
+#include <agency/scoped_executor.hpp>
 #include <atomic>
 #include <algorithm>
 #include <cassert>
@@ -272,7 +272,7 @@ int main()
   test<agency::parallel_executor>(10);
   test<agency::concurrent_executor>(10);
 
-  using executor_type = agency::nested_executor<agency::concurrent_executor,agency::sequential_executor>;
+  using executor_type = agency::scoped_executor<agency::concurrent_executor,agency::sequential_executor>;
   test_nested<executor_type>(executor_type::shape_type(4,4));
 
   std::cout << "OK" << std::endl;

--- a/testing/test_multi_agent_when_all_execute_and_select_with_shared_inits_old.cpp
+++ b/testing/test_multi_agent_when_all_execute_and_select_with_shared_inits_old.cpp
@@ -8,7 +8,7 @@ struct my_executor {};
 
 struct my_scoped_executor
 {
-  using execution_category = agency::nested_execution_tag<
+  using execution_category = agency::scoped_execution_tag<
     agency::sequential_execution_tag,
     agency::sequential_execution_tag
   >;


### PR DESCRIPTION
Replace "nested_" with "member_" when referring to members of types

Fixes #74