### PR TITLE
Add a Shape template parameter to single_element_container

### DIFF
--- a/agency/detail/executor_traits/single_agent_execute.hpp
+++ b/agency/detail/executor_traits/single_agent_execute.hpp
@@ -57,9 +57,10 @@ typename std::result_of<Function()>::type
                             >::type* = 0)
 {
   using value_type = typename std::result_of<Function()>::type;
-  using container_type = single_element_container<value_type>;
-
   using shape_type = typename executor_traits<Executor>::shape_type;
+
+  using container_type = single_element_container<value_type,shape_type>;
+
   using index_type = typename executor_traits<Executor>::index_type;
 
   return executor_traits<Executor>::execute(ex, [&](const index_type&)

--- a/agency/detail/executor_traits/single_element_container.hpp
+++ b/agency/detail/executor_traits/single_element_container.hpp
@@ -10,14 +10,14 @@ namespace executor_traits_detail
 {
 
 
-template<class T>
+template<class T, class Shape>
 struct single_element_container
 {
+  __agency_exec_check_disable__
   __AGENCY_ANNOTATION
-  single_element_container() {}
+  single_element_container() : element{} {}
 
   __agency_exec_check_disable__
-  template<class Shape>
   __AGENCY_ANNOTATION
   single_element_container(const Shape&) : element{} {}
 

--- a/testing/bulk_async/multiple_results.cpp
+++ b/testing/bulk_async/multiple_results.cpp
@@ -89,14 +89,9 @@ int main()
   test(con(10, par(10)));
   test(con(10, con(10)));
 
-  // XXX this test crashes
-  //test(par(10, seq(10)));
-
-  // XXX this test fails
-  //test(par(10, con(10)));
-  
-  // XXX this test fails
-  //test(par(10, par(10)));
+  test(par(10, seq(10)));
+  test(par(10, con(10)));
+  test(par(10, par(10)));
 
   std::cout << "OK" << std::endl;
 


### PR DESCRIPTION
This allows distinguishing between single_element_container's copy
constructor and shape constructor

Fixes #189